### PR TITLE
Add favicon links

### DIFF
--- a/ui/src/app.html
+++ b/ui/src/app.html
@@ -2,7 +2,14 @@
 <html lang="en">
 	<head>
 		<meta charset="utf-8" />
-		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<!-- basic favicon (keep existing favicon) -->
+		<link rel="icon" type="image/png" href="%sveltekit.assets%/favicon.svg" />
+
+		<!-- additional common sizes / apple -->
+		<link rel="icon" type="image/svg+xml" sizes="32x32" href="%sveltekit.assets%/favicon-32x32.svg" />
+		<link rel="icon" type="image/svg+xml" sizes="16x16" href="%sveltekit.assets%/favicon-16x16.svg" />
+		<link rel="apple-touch-icon" sizes="180x180" href="%sveltekit.assets%/apple-touch-icon.svg" />
+
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		<title>NetVisor</title>
 		%sveltekit.head%


### PR DESCRIPTION
Adds standard favicon/link tags to the UI.

What I changed:
- Updated ui/src/app.html to include favicon links for 32x32, 16x16, apple-touch