### PR TITLE
fix: remove hardcoded http:// prefix to prevent malformed connection URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     restart: unless-stopped
     environment:
       <<: *netvisor-env
-      NETVISOR_SERVER_TARGET: ${NETVISOR_SERVER_TARGET:-http://127.0.0.1}
+      NETVISOR_SERVER_TARGET: ${NETVISOR_SERVER_TARGET:-127.0.0.1}
       NETVISOR_PORT: ${NETVISOR_DAEMON_PORT:-60073}
       NETVISOR_BIND_ADDRESS: ${NETVISOR_BIND_ADDRESS:-0.0.0.0}
       NETVISOR_NAME: ${NETVISOR_NAME:-netvisor-daemon}


### PR DESCRIPTION
When NETVISOR_SERVER_TARGET is set with http:// prefix (e.g., http://localhost), the hardcoded http:// in default value causes malformed connection URL (http://http://localhost). This could lead to connection failures between services.

Remove the hardcoded prefix to ensure proper URL formation regardless of how NETVISOR_SERVER_TARGET is set.