### PR TITLE
feat: add Paperless-NGX service definition

### DIFF
--- a/backend/src/server/services/definitions/mod.rs
+++ b/backend/src/server/services/definitions/mod.rs
@@ -118,6 +118,7 @@ pub mod nut;
 pub mod open_media_vault;
 pub mod opn_sense;
 pub mod overseerr;
+pub mod paperless_ngx;
 pub mod pf_blocker_ng;
 pub mod pf_sense;
 pub mod philips_hue_bridge;

--- a/backend/src/server/services/definitions/paperless_ngx.rs
+++ b/backend/src/server/services/definitions/paperless_ngx.rs
@@ -1,0 +1,36 @@
+use crate::server::hosts::r#impl::ports::PortBase;
+use crate::server::services::definitions::{ServiceDefinitionFactory, create_service};
+use crate::server::services::r#impl::categories::ServiceCategory;
+use crate::server::services::r#impl::definitions::ServiceDefinition;
+use crate::server::services::r#impl::patterns::Pattern;
+
+#[derive(Default, Clone, Eq, PartialEq, Hash)]
+pub struct PaperlessNGX;
+
+impl ServiceDefinition for PaperlessNGX {
+    fn name(&self) -> &'static str {
+        "Paperless-NGX"
+    }
+    fn description(&self) -> &'static str {
+        "Community-supported document management system"
+    }
+    fn category(&self) -> ServiceCategory {
+        ServiceCategory::Web
+    }
+
+    fn discovery_pattern(&self) -> Pattern<'_> {
+        Pattern::Endpoint(
+            PortBase::new_tcp(8000),
+            "/accounts/login/",
+            "Paperless-ngx project",
+        )
+    }
+
+    fn logo_url(&self) -> &'static str {
+        "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/paperless-ngx.svg"
+    }
+}
+
+inventory::submit!(ServiceDefinitionFactory::new(
+    create_service::<PaperlessNGX>
+));


### PR DESCRIPTION
## Add service definition for Paperless-NGX

**Description**: Document Management application

**Official Website**: [Docs](https://docs.paperless-ngx.com/), [Github](https://github.com/paperless-ngx/paperless-ngx)

**Default Ports**: 8000

**Discovery Method**:
- Pattern type: Endpoint - `("/accounts/login/", "Paperless-ngx project")`
- Reasoning: The root ("/") didn't seem to detect the service

**Icon Source**: Dashboard Icon

**Testing**: 
- [x] Compiles successfully
- [x] Tested against real instance (describe setup below)
- [ ] Unable to test (explain why below)

**Testing Details**: 
Tested on my prod instance