### PR TITLE
Add Pocket-ID service definition

### DIFF
--- a/backend/src/server/services/definitions/mod.rs
+++ b/backend/src/server/services/definitions/mod.rs
@@ -124,6 +124,7 @@ pub mod pf_sense;
 pub mod philips_hue_bridge;
 pub mod pi_hole;
 pub mod plex;
+pub mod pocket_id;
 pub mod portainer;
 pub mod power_dns;
 pub mod print_server;

--- a/backend/src/server/services/definitions/pocket_id.rs
+++ b/backend/src/server/services/definitions/pocket_id.rs
@@ -1,0 +1,30 @@
+use crate::server::hosts::r#impl::ports::PortBase;
+use crate::server::services::definitions::{ServiceDefinitionFactory, create_service};
+use crate::server::services::r#impl::categories::ServiceCategory;
+use crate::server::services::r#impl::definitions::ServiceDefinition;
+use crate::server::services::r#impl::patterns::Pattern;
+
+#[derive(Default, Clone, Eq, PartialEq, Hash)]
+pub struct PocketID;
+
+impl ServiceDefinition for PocketID {
+    fn name(&self) -> &'static str {
+        "Pocket ID"
+    }
+    fn description(&self) -> &'static str {
+        "A Simple OIDC provider that uses passkeys for authentication"
+    }
+    fn category(&self) -> ServiceCategory {
+        ServiceCategory::Web
+    }
+
+    fn discovery_pattern(&self) -> Pattern<'_> {
+        Pattern::Endpoint(PortBase::new_tcp(1411), "/app.webmanifest", "Pocket ID")
+    }
+
+    fn logo_url(&self) -> &'static str {
+        "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/pocket-id-light.svg"
+    }
+}
+
+inventory::submit!(ServiceDefinitionFactory::new(create_service::<PocketID>));


### PR DESCRIPTION
## Add service definition for Pocket-ID

**Description**: Passwordless OIDC provider

**Official Website**: [Pocket-ID](https://pocket-id.org)

**Default Ports**: 1411

**Discovery Method**:
- Pattern type: Endpoint - `("/app.webmanifest", "Pocket ID")`
- Reasoning: This endpoint returns the name of the app

**Icon Source**: Dashboard Icons - light version

**Testing**: 
- [x] Compiles successfully
- [x] Tested against real instance (describe setup below)
- [ ] Unable to test (explain why below)

**Testing Details**: 
Tested on my prod version. Service is detected.