### PR TITLE
Add Karakeep service definition

### DIFF
--- a/backend/src/server/services/definitions/karakeep.rs
+++ b/backend/src/server/services/definitions/karakeep.rs
@@ -1,0 +1,30 @@
+use crate::server::hosts::r#impl::ports::PortBase;
+use crate::server::services::definitions::{ServiceDefinitionFactory, create_service};
+use crate::server::services::r#impl::categories::ServiceCategory;
+use crate::server::services::r#impl::definitions::ServiceDefinition;
+use crate::server::services::r#impl::patterns::Pattern;
+
+#[derive(Default, Clone, Eq, PartialEq, Hash)]
+pub struct Karakeep;
+
+impl ServiceDefinition for Karakeep {
+    fn name(&self) -> &'static str {
+        "Karakeep"
+    }
+    fn description(&self) -> &'static str {
+        "The Bookmark Everything App"
+    }
+    fn category(&self) -> ServiceCategory {
+        ServiceCategory::Media
+    }
+
+    fn discovery_pattern(&self) -> Pattern<'_> {
+        Pattern::Endpoint(PortBase::new_tcp(3000), "/manifest.json", "Karakeep")
+    }
+
+    fn logo_url(&self) -> &'static str {
+        "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/karakeep.svg"
+    }
+}
+
+inventory::submit!(ServiceDefinitionFactory::new(create_service::<Karakeep>));

--- a/backend/src/server/services/definitions/mod.rs
+++ b/backend/src/server/services/definitions/mod.rs
@@ -99,6 +99,7 @@ pub mod jellyfin;
 pub mod jellyseerr;
 pub mod jellystat;
 pub mod jump;
+pub mod karakeep;
 pub mod komga;
 pub mod kubernetes;
 pub mod lidarr;


### PR DESCRIPTION
## Add service definition for Karakeep

**Description**: Self-hosted everything bookmarker

**Official Website**: https://karakeep.app

**Default Ports**: 3000
**Discovery Method**:
- Pattern type: Endpoint - `("/manifest.json", "Karakeep")`
- Reasoning: The manifest.json has the info

**Icon Source**: Dashboard Icons

**Testing**: 
- [x] Compiles successfully
- [x] Tested against real instance (describe setup below)
- [ ] Unable to test (explain why below)

**Testing Details**: 
Tested in my prod instance

**Additional Notes**: 
I have a few more - can I put them in one PR?