### PR TITLE
Add support for self-signed certificates in CLI and configuration

### DIFF
--- a/backend/src/bin/daemon.rs
+++ b/backend/src/bin/daemon.rs
@@ -68,6 +68,10 @@ struct Cli {
     /// Docker socket proxy
     #[arg(long)]
     docker_proxy: Option<String>,
+
+    /// Allow self-signed certificates
+    #[arg(long)]
+    allow_self_signed_certs: Option<bool>,
 }
 
 impl From<Cli> for CliArgs {
@@ -84,6 +88,7 @@ impl From<Cli> for CliArgs {
             concurrent_scans: cli.concurrent_scans,
             daemon_api_key: cli.daemon_api_key,
             docker_proxy: cli.docker_proxy,
+            allow_self_signed_certs: cli.allow_self_signed_certs,
         }
     }
 }

--- a/backend/src/daemon/runtime/service.rs
+++ b/backend/src/daemon/runtime/service.rs
@@ -21,9 +21,19 @@ pub struct DaemonRuntimeService {
 
 impl DaemonRuntimeService {
     pub fn new(config_store: Arc<ConfigStore>) -> Self {
+        let mut client_builder = reqwest::Client::builder();
+
+        if config_store
+            .get_allow_self_signed_certs()
+            .unwrap_or(Some(false))
+            .unwrap_or(false)
+        {
+            client_builder = client_builder.danger_accept_invalid_certs(true);
+        }
+
         Self {
             config_store,
-            client: reqwest::Client::new(),
+            client: client_builder.build().unwrap(),
             utils: create_system_utils(),
         }
     }

--- a/backend/src/daemon/shared/storage.rs
+++ b/backend/src/daemon/shared/storage.rs
@@ -24,6 +24,7 @@ pub struct CliArgs {
     pub concurrent_scans: Option<usize>,
     pub daemon_api_key: Option<String>,
     pub docker_proxy: Option<String>,
+    pub allow_self_signed_certs: Option<bool>,
 }
 
 /// Unified configuration struct that handles both startup and runtime config
@@ -48,6 +49,7 @@ pub struct AppConfig {
     pub host_id: Option<Uuid>,
     pub daemon_api_key: Option<String>,
     pub docker_proxy: Option<String>,
+    pub allow_self_signed_certs: Option<bool>,
 }
 
 impl Default for AppConfig {
@@ -67,6 +69,7 @@ impl Default for AppConfig {
             daemon_api_key: None,
             concurrent_scans: 15,
             docker_proxy: None,
+            allow_self_signed_certs: None,
         }
     }
 }
@@ -126,6 +129,9 @@ impl AppConfig {
         }
         if let Some(docker_proxy) = cli_args.docker_proxy {
             figment = figment.merge(("docker_proxy", docker_proxy));
+        }
+        if let Some(allow_self_signed_certs) = cli_args.allow_self_signed_certs {
+            figment = figment.merge(("allow_self_signed_certs", allow_self_signed_certs));
         }
 
         let config: AppConfig = figment
@@ -280,6 +286,11 @@ impl ConfigStore {
     pub async fn get_docker_proxy(&self) -> Result<Option<String>> {
         let config = self.config.read().await;
         Ok(config.docker_proxy.clone())
+    }
+
+    pub fn get_allow_self_signed_certs(&self) -> Result<Option<bool>> {
+        let config = self.config.try_read()?;
+        Ok(config.allow_self_signed_certs)
     }
 
     pub async fn get_heartbeat_interval(&self) -> Result<u64> {


### PR DESCRIPTION
This pull request introduces support for allowing self-signed SSL certificates in the daemon's HTTP client configuration. The main changes add a new configuration option to enable or disable acceptance of self-signed certificates, propagate this setting through the configuration system, and update the HTTP client initialization logic accordingly.

Configuration changes:

* Added a new `allow_self_signed_certs` option to both the `CliArgs` and `AppConfig` structs, with corresponding updates to their default implementations and configuration merging logic. [[1]](diffhunk://#diff-e66af06ecbeba04dadef195b88a0565f031d2481dec7c9ab619917ec3cfb7476R27) [[2]](diffhunk://#diff-e66af06ecbeba04dadef195b88a0565f031d2481dec7c9ab619917ec3cfb7476R52) [[3]](diffhunk://#diff-e66af06ecbeba04dadef195b88a0565f031d2481dec7c9ab619917ec3cfb7476R72) [[4]](diffhunk://#diff-e66af06ecbeba04dadef195b88a0565f031d2481dec7c9ab619917ec3cfb7476R133-R135)
* Added a `get_allow_self_signed_certs` method to the `ConfigStore` to retrieve the new configuration value.

HTTP client initialization:

* Updated the `DaemonRuntimeService::new` method to use the `allow_self_signed_certs` configuration: if enabled, the HTTP client is built to accept invalid (self-signed) certificates.