### PR TITLE
Fix Docker volume path mismatch in compose template

### DIFF
--- a/ui/src/lib/templates/docker-compose.daemon.yml
+++ b/ui/src/lib/templates/docker-compose.daemon.yml
@@ -18,7 +18,7 @@ services:
       - NETVISOR_HEARTBEAT_INTERVAL=30
       - NETVISOR_NETWORK_ID=0
     volumes:
-      - daemon-config:/root/.config/netvisor/daemon
+      - daemon-config:/root/.config/daemon
       # Comment out the line below to disable docker discovery
       - /var/run/docker.sock:/var/run/docker.sock:ro
 


### PR DESCRIPTION
## Problem

The current Docker Compose template has a volume path mismatch that prevents configuration persistence:

- **Volume mount path**: `/root/.config/netvisor/daemon`
- **Actual config path**: `/root/.config/daemon/config.json` (as shown in daemon logs)

## Solution

Updated the volume mount path to match the daemon's actual configuration directory:

```diff
-       - daemon-config:/root/.config/netvisor/daemon
+       - daemon-config:/root/.config/daemon
```

### Evidence

```
> docker compose up
[+] Running 1/1
 ✔ Container netvisor-daemon  Recreated                                                                                                                                0.0s
Attaching to netvisor-daemon
netvisor-daemon  | 2025-11-14T16:14:17.351004Z  INFO daemon: 🤖 NetVisor daemon starting
netvisor-daemon  | 2025-11-14T16:14:17.351205Z  INFO netvisor::daemon::shared::storage: No existing runtime config found, will create new on first save
netvisor-daemon  | 2025-11-14T16:14:17.351414Z  INFO daemon: 🌐 Listening on: 0.0.0.0:60073
netvisor-daemon  | 2025-11-14T16:14:17.351420Z  INFO daemon: 📁 Config file: "/root/.config/daemon/config.json"
netvisor-daemon  | 2025-11-14T16:14:17.351423Z  INFO daemon: 🔗 Server at http://localhost:60072
netvisor-daemon  | 2025-11-14T16:14:17.351426Z  INFO daemon: Network ID available: 84b8b9f0-07ee-471e-a5b5-463bfbf4c0b7
netvisor-daemon  | 2025-11-14T16:14:17.351429Z  INFO daemon: API key available: [redacted]
netvisor-daemon  | 2025-11-14T16:14:17.353876Z  INFO netvisor::daemon::runtime::service: Registering with server...
```