### PR TITLE
[Fix]: Improve Plex service detection pattern

### DIFF
--- a/backend/src/server/services/definitions/plex.rs
+++ b/backend/src/server/services/definitions/plex.rs
@@ -22,7 +22,7 @@ impl ServiceDefinition for Plex {
         Pattern::AnyOf(vec![
             Pattern::Endpoint(PortBase::new_tcp(32400), "/web/index.html", "Plex", None),
             Pattern::Header(
-                PortBase::new_tcp(32400),
+                Some(PortBase::new_tcp(32400)),
                 "X-Plex-Protocol",
                 "1.0",
                 Some(401..401),


### PR DESCRIPTION
- This PR adds A check for the `X-Plex-Protocol` header to the Plex service detection pattern.
- It looks for a 401 response as that is what is returned when making an unauthenticated request to the root endpoint.
- The pattern is combined with the existing endpoint check at `/web/index.html` as an 'AnyOf' pattern.
- I found that adding this helped detect Plex again after it stopped being detected during recent updates.