### PR TITLE
Adjust endpoint pattern for Paperless-ngx

### DIFF
--- a/backend/src/server/services/definitions/paperless_ngx.rs
+++ b/backend/src/server/services/definitions/paperless_ngx.rs
@@ -19,12 +19,7 @@ impl ServiceDefinition for PaperlessNGX {
     }
 
     fn discovery_pattern(&self) -> Pattern<'_> {
-        Pattern::Endpoint(
-            PortBase::new_tcp(8000),
-            "/accounts/login/?",
-            "Paperless-ngx project",
-            None,
-        )
+        Pattern::Endpoint(PortBase::new_tcp(8000), "/", "Paperless-ngx project", None)
     }
 
     fn logo_url(&self) -> &'static str {


### PR DESCRIPTION
- The `/accounts/login/?` endpoint doesn't appear to be detected when specified.
- Just using the root, and letting the 302 return code redirect to the `/accounts/login/?=/` endpoint results in a correct detection.