### PR TITLE
[Fix]: Use server-url for dev-daemon in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ dev-server:
 	cd backend && cargo run --bin server -- --log-level debug
 
 dev-daemon:
-	cd backend && cargo run --bin daemon -- --server-target http://127.0.0.1 --server-port 60072 --log-level debug
+	cd backend && cargo run --bin daemon -- --server-url http://127.0.0.1:60072 --log-level debug
 
 dev-ui:
 	cd ui && npm run dev


### PR DESCRIPTION
This just uses `--server-url` in the `dev-daemon` Makefile command so that running the daemon in a dev environment doesn't fail.