### PR TITLE
[FIX]: Improve Paperless-ngx service detection

### DIFF
--- a/backend/src/server/services/definitions/paperless_ngx.rs
+++ b/backend/src/server/services/definitions/paperless_ngx.rs
@@ -19,7 +19,12 @@ impl ServiceDefinition for PaperlessNGX {
     }
 
     fn discovery_pattern(&self) -> Pattern<'_> {
-        Pattern::Endpoint(PortBase::new_tcp(8000), "/", "Paperless-ngx project", None)
+        Pattern::Endpoint(
+            PortBase::new_tcp(8000),
+            "/static/frontend/en-US/manifest.webmanifest",
+            "Paperless-ngx",
+            None,
+        )
     }
 
     fn logo_url(&self) -> &'static str {


### PR DESCRIPTION
- located a webmanifest file to use instead of the root endpoint:

```
fn discovery_pattern(&self) -> Pattern<'_> {
        Pattern::Endpoint(
            PortBase::new_tcp(8000),
            "/static/frontend/en-US/manifest.webmanifest",
            "Paperless-ngx",
            None,
        )
    }
```