### PR TITLE
Potential fix for code scanning alert no. 1: Code injection

### DIFF
--- a/.github/workflows/pr_dev_only.yml
+++ b/.github/workflows/pr_dev_only.yml
@@ -8,8 +8,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check branches
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          BASE_REF: ${{ github.base_ref }}
         run: |
-          if [ ${{ github.head_ref }} != "dev" ] && [ ${{ github.base_ref }} == "main" ]; then
+          if [ "$HEAD_REF" != "dev" ] && [ "$BASE_REF" = "main" ]; then
             echo "Merge requests to main branch are only allowed from dev branch."
             exit 1
-          fi   
+          fi


### PR DESCRIPTION
Potential fix for [https://github.com/mayanayza/netvisor/security/code-scanning/1](https://github.com/mayanayza/netvisor/security/code-scanning/1)

The best way to fix this is to refactor the usage of `github.head_ref` and `github.base_ref` so that their values are assigned to environment variables first, and then those variables are referenced using native shell syntax (i.e., `$HEAD_REF` and `$BASE_REF`) inside double quotes for safe comparison. This prevents malicious branch names from breaking out of the shell statement and injecting arbitrary shell commands.  
Specifically, you should:
- Use the `env:` block to assign `${{ github.head_ref }}` and `${{ github.base_ref }}` to environment variables.
- In the `run:` step, reference those variables using proper shell quoting: `"$HEAD_REF"` and `"$BASE_REF"`.
- The rest of the logic (the comparison and error message) remains unchanged.

This edit affects the `run:` and its corresponding lines in `.github/workflows/pr_dev_only.yml`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
