### PR TITLE
[FIX]: daemon install command

### DIFF
--- a/ui/src/lib/features/daemons/components/CreateDaemonModal.svelte
+++ b/ui/src/lib/features/daemons/components/CreateDaemonModal.svelte
@@ -49,7 +49,7 @@
 		}
 	}
 
-	const installCommand = `curl -sSL https://raw.githubusercontent.com/mayanayza/netvisor/refs/heads/main/install.sh | bash`;
+	const installCommand = `bash -c "$(curl -fsSL https://raw.githubusercontent.com/mayanayza/netvisor/refs/heads/main/install.sh)"`;
 	$: runCommand = `netvisor-daemon --server-url ${serverUrl} ${!daemon ? `--network-id ${selectedNetworkId}` : ''} ${key ? `--daemon-api-key ${key} --mode ${$daemonModeField.value.toLowerCase()}` : ''}`;
 
 	let dockerCompose = '';


### PR DESCRIPTION
This PR changes the install command to a more stable version that maintains the prompt response when pasted into a shell.

I tested on a dev instance and the script successfully installed the daemon, and then allowed me to choose whether to install the systemd service, as intended.