### PR TITLE
Add service definition for cAdvisor

### DIFF
--- a/backend/src/server/services/definitions/cadvisor.rs
+++ b/backend/src/server/services/definitions/cadvisor.rs
@@ -1,0 +1,33 @@
+use crate::server::hosts::r#impl::ports::PortBase;
+use crate::server::services::definitions::{ServiceDefinitionFactory, create_service};
+use crate::server::services::r#impl::categories::ServiceCategory;
+use crate::server::services::r#impl::definitions::ServiceDefinition;
+use crate::server::services::r#impl::patterns::Pattern;
+
+#[derive(Default, Clone, Eq, PartialEq, Hash)]
+pub struct Cadvisor;
+
+impl ServiceDefinition for Cadvisor {
+    fn name(&self) -> &'static str {
+        "cAdvisor"
+    }
+    fn description(&self) -> &'static str {
+        "Graph database"
+    }
+    fn category(&self) -> ServiceCategory {
+        ServiceCategory::Database
+    }
+    fn discovery_pattern(&self) -> Pattern<'_> {
+        Pattern::Endpoint(
+            PortBase::Http8080,
+            "/api/v1.0/containers/",
+            "cAdvisor",
+            None,
+        )
+    }
+    fn logo_url(&self) -> &'static str {
+        "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/cadvisor.png"
+    }
+}
+
+inventory::submit!(ServiceDefinitionFactory::new(create_service::<Cadvisor>));

--- a/backend/src/server/services/definitions/mod.rs
+++ b/backend/src/server/services/definitions/mod.rs
@@ -241,6 +241,7 @@ pub mod proxmox_datacenter_manager;
 
 // Monitoring
 pub mod apc;
+pub mod cadvisor;
 pub mod coolercontrol;
 pub mod elastic_apm;
 pub mod gatus;

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -291,6 +291,12 @@ This document lists all services that NetVisor can automatically discover and id
 <td style="padding: 12px;"><code style="background-color: #374151; color: #e5e7eb; padding: 2px 6px; border-radius: 3px; font-size: 0.875em;">Endpoint response body from <ip>:5984/ contains "couchdb"</code></td>
 </tr>
 <tr style="border-bottom: 1px solid #374151;">
+<td align="center" style="padding: 12px; color: #d1d5db;"><img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/denodo.svg" alt="CouchDB" width="32" height="32" /></td>
+<td style="padding: 12px; color: #f3f4f6; font-weight: 500;">Denodo</td>
+<td style="padding: 12px; color: #d1d5db;">Data Virtualization</td>
+<td style="padding: 12px;"><code style="background-color: #374151; color: #e5e7eb; padding: 2px 6px; border-radius: 3px; font-size: 0.875em;">Any of: (9999/tcp (VDP) is open, 9996/tcp (ODBC) is open, 9090/tcp (HTTP) is open, 9099/tcp (Web container) is open)</code></td>
+</tr>
+<tr style="border-bottom: 1px solid #374151;">
 <td align="center" style="padding: 12px; color: #d1d5db;"><img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/elasticsearch.svg" alt="Elasticsearch" width="32" height="32" /></td>
 <td style="padding: 12px; color: #f3f4f6; font-weight: 500;">Elasticsearch</td>
 <td style="padding: 12px; color: #d1d5db;">Distributed search and analytics engine</td>
@@ -934,6 +940,12 @@ This document lists all services that NetVisor can automatically discover and id
 <td style="padding: 12px; color: #f3f4f6; font-weight: 500;">APC</td>
 <td style="padding: 12px; color: #d1d5db;">APC Network-Connected UPS</td>
 <td style="padding: 12px;"><code style="background-color: #374151; color: #e5e7eb; padding: 2px 6px; border-radius: 3px; font-size: 0.875em;">Endpoint response body from <ip>:80/ contains "Schneider Electric"</code></td>
+</tr>
+<tr style="border-bottom: 1px solid #374151;">
+<td align="center" style="padding: 12px; color: #d1d5db;"><img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/cadvisor.png" alt="cAdvisor" width="32" height="32" /></td>
+<td style="padding: 12px; color: #f3f4f6; font-weight: 500;">cAdvisor</td>
+<td style="padding: 12px; color: #d1d5db;">Analyzes resource usage and performance characteristics of running containers.</td>
+<td style="padding: 12px;"><code style="background-color: #374151; color: #e5e7eb; padding: 2px 6px; border-radius: 3px; font-size: 0.875em;">Endpoint response body from <ip>:8080/api/v1.2/containers contains "cAdvisor"</code></td>
 </tr>
 <tr style="border-bottom: 1px solid #374151;">
 <td align="center" style="padding: 12px; color: #d1d5db;"><img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/cooler-control.svg" alt="CoolerControl" width="32" height="32" /></td>


### PR DESCRIPTION
## Add service definition for cAdvisor

**Description**: Analyzes resource usage and performance characteristics of running containers.

**Official Website**: [cAdvisor](https://github.com/google/cadvisor)

**Discovery Method**: 
- Pattern type: Endpoint
- Reasoning: According to the cAdvisor documentation, the API endpoint is the way to retrieve data

**Icon Source**: [Dashboard Icons/Simple Icons/Vector Logo Zone]

**Testing**: 
- [x] Compiles successfully
- [ ] Tested against real instance (describe setup below)
- [x] Unable to test (explain why below)
- [x] Format : Passed
- [x] Linter : Passed

**Testing Details**: 
Problem with the creation of Docker containers during the test phase. Cause: Volume creation.
Workspace on NFS drive with access restrictions.
Need to conduct an analysis of the infrastructure and rights management while ensuring the security of the infrastructure
