### PR TITLE
Add definition for service Denodo

### DIFF
--- a/backend/src/server/services/definitions/denodo.rs
+++ b/backend/src/server/services/definitions/denodo.rs
@@ -1,0 +1,35 @@
+use crate::server::hosts::r#impl::ports::PortBase;
+use crate::server::services::definitions::{ServiceDefinitionFactory, create_service};
+use crate::server::services::r#impl::categories::ServiceCategory;
+use crate::server::services::r#impl::definitions::ServiceDefinition;
+use crate::server::services::r#impl::patterns::Pattern;
+
+#[derive(Default, Clone, Eq, PartialEq, Hash)]
+pub struct Denodo;
+
+impl ServiceDefinition for Denodo {
+    fn name(&self) -> &'static str {
+        "Denodo"
+    }
+    fn description(&self) -> &'static str {
+        "Data virtualization"
+    }
+    fn category(&self) -> ServiceCategory {
+        ServiceCategory::Database
+    }
+
+    fn discovery_pattern(&self) -> Pattern<'_> {
+        Pattern::AllOf(vec![
+            Pattern::Port(PortBase::new_tcp(9990)),
+            Pattern::Port(PortBase::new_tcp(9996)),
+            Pattern::Port(PortBase::new_tcp(9090)),
+            Pattern::Port(PortBase::new_tcp(9099)),
+        ])
+    }
+
+    fn logo_url(&self) -> &'static str {
+        "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/denodo.svg"
+    }
+}
+
+inventory::submit!(ServiceDefinitionFactory::new(create_service::<Denodo>));

--- a/backend/src/server/services/definitions/mod.rs
+++ b/backend/src/server/services/definitions/mod.rs
@@ -173,6 +173,7 @@ pub mod rancher;
 // Database
 pub mod cassandra;
 pub mod couchdb;
+pub mod denodo;
 pub mod elasticsearch;
 pub mod influxdb;
 pub mod mariadb;

--- a/docs/SERVICES.md
+++ b/docs/SERVICES.md
@@ -290,6 +290,12 @@ This document lists all services that NetVisor can automatically discover and id
 <td style="padding: 12px; color: #d1d5db;">NoSQL document database</td>
 <td style="padding: 12px;"><code style="background-color: #374151; color: #e5e7eb; padding: 2px 6px; border-radius: 3px; font-size: 0.875em;">Endpoint response body from <ip>:5984/ contains "couchdb"</code></td>
 </tr>
+<td align="center" style="padding: 12px; color: #d1d5db;"><img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/denodo.svg" alt="CouchDB" width="32" height="32" /></td>
+<td style="padding: 12px; color: #f3f4f6; font-weight: 500;">Denodo</td>
+<td style="padding: 12px; color: #d1d5db;">Data Virtualization</td>
+<td style="padding: 12px;"><code style="background-color: #374151; color: #e5e7eb; padding: 2px 6px; border-radius: 3px; font-size: 0.875em;">Any of: (9999/tcp (VDP) is open, 9996/tcp (ODBC) is open, 9090/tcp (HTTP) is open, 9099/tcp (Web container) is open)</code></td>
+</tr>
+<tr style="border-bottom: 1px solid #374151;">
 <tr style="border-bottom: 1px solid #374151;">
 <td align="center" style="padding: 12px; color: #d1d5db;"><img src="https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/elasticsearch.svg" alt="Elasticsearch" width="32" height="32" /></td>
 <td style="padding: 12px; color: #f3f4f6; font-weight: 500;">Elasticsearch</td>


### PR DESCRIPTION
Description: Add definitions service for Denodo

Official Website: https://www.denodo.com/fr

Default Ports: (Principals)
9990: Virtual Data Port
9996: ODBC Port
9090: WebUI Port (Denodo Studio)
9099: Web container Serveur Port

Icon Source: Dashboard Icons

Testing:

- [x] Compiles successfully
- [ ]  Tested against real instance (describe setup below)
- [ ]  Unable to test (explain why below)
- [x]  Format : Passed
- [x]  Linter : Passed

Testing Details:
Problem with the creation of Docker containers during the test phase. Cause: Volume creation.
Workspace on NFS drive with access restrictions.
Need to conduct an analysis of the infrastructure and rights management while ensuring the security of the infrastructure
