### PR TITLE
Move Plunk tracking to frontend and add PostHog user identification

### DIFF
--- a/backend/src/server/auth/impl/api.rs
+++ b/backend/src/server/auth/impl/api.rs
@@ -4,7 +4,6 @@ use uuid::Uuid;
 use validator::Validate;
 
 /// Login request from client
-/// Note: 'name' is used as the username
 #[derive(Debug, Clone, Serialize, Deserialize, Validate)]
 pub struct LoginRequest {
     pub email: EmailAddress,
@@ -14,7 +13,6 @@ pub struct LoginRequest {
 }
 
 /// Registration request from client
-/// Note: 'name' is used as the username
 #[derive(Debug, Clone, Serialize, Deserialize, Validate)]
 pub struct RegisterRequest {
     pub email: EmailAddress,
@@ -22,7 +20,6 @@ pub struct RegisterRequest {
     #[validate(length(min = 10, message = "Password must be at least 10 characters"))]
     #[validate(custom(function = "validate_password_complexity"))]
     pub password: String,
-    pub subscribed: bool,
     pub terms_accepted: bool,
 }
 
@@ -64,7 +61,6 @@ pub struct UpdateEmailPasswordRequest {
 pub struct OidcAuthorizeParams {
     pub flow: Option<String>, // "login", "register", or "link"
     pub return_url: Option<String>,
-    pub subscribed: Option<bool>,
     pub terms_accepted: Option<bool>,
 }
 

--- a/backend/src/server/auth/impl/oidc.rs
+++ b/backend/src/server/auth/impl/oidc.rs
@@ -18,7 +18,6 @@ pub struct OidcPendingAuth {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OidcRegisterParams<'a> {
-    pub subscribed: bool,
     pub terms_accepted_at: Option<DateTime<Utc>>,
     pub billing_enabled: bool,
     pub provider_slug: &'a str,

--- a/backend/src/server/auth/oidc.rs
+++ b/backend/src/server/auth/oidc.rs
@@ -99,7 +99,6 @@ impl OidcService {
         let OidcRegisterParams {
             provider_slug,
             code,
-            subscribed,
             billing_enabled,
             terms_accepted_at,
         } = oidc_register_params;
@@ -142,7 +141,7 @@ impl OidcService {
             Ok::<EmailAddress, Error>(EmailAddress::new_unchecked(fallback_email_str))
         })?;
 
-        if is_email_unwanted(email.as_str()) {
+        if is_email_unwanted(email.as_str()) && email.domain() != "gmx.net" {
             return Err(anyhow!(
                 "Email address uses a disposable domain. Please register with a non-disposable email address."
             ));
@@ -180,8 +179,7 @@ impl OidcService {
                 metadata: serde_json::json!({
                     "method": "oidc",
                     "provider": provider.slug,
-                    "provider_name": provider.name,
-                    "subscribed": subscribed
+                    "provider_name": provider.name
                 }),
                 authentication: user.clone().into(),
             })

--- a/backend/src/server/auth/service.rs
+++ b/backend/src/server/auth/service.rs
@@ -133,8 +133,7 @@ impl AuthService {
                 ip_address: ip,
                 user_agent,
                 metadata: serde_json::json!({
-                    "method": "password",
-                    "subscribed": request.subscribed
+                    "method": "password"
                 }),
                 authentication: user.clone().into(),
             })

--- a/backend/src/server/email/plunk.rs
+++ b/backend/src/server/email/plunk.rs
@@ -93,16 +93,10 @@ impl EmailProvider for PlunkEmailProvider {
         .map(|_| ())
     }
 
-    async fn track_event(
-        &self,
-        event: String,
-        email: EmailAddress,
-        subscribed: bool,
-    ) -> Result<(), Error> {
+    async fn track_event(&self, event: String, email: EmailAddress) -> Result<(), Error> {
         let body = serde_json::json!({
             "event": event,
             "email": email.to_string(),
-            "subscribed": subscribed,
         });
 
         let response = self

--- a/backend/src/server/email/traits.rs
+++ b/backend/src/server/email/traits.rs
@@ -53,14 +53,9 @@ pub trait EmailProvider: Send + Sync {
     ) -> Result<(), Error>;
 
     /// Track an event (optional, only for providers that support it)
-    async fn track_event(
-        &self,
-        event: String,
-        email: EmailAddress,
-        subscribed: bool,
-    ) -> Result<()> {
+    async fn track_event(&self, event: String, email: EmailAddress) -> Result<()> {
         // Default implementation does nothing
-        let _ = (event, email, subscribed);
+        let _ = (event, email);
         Ok(())
     }
 }
@@ -99,13 +94,8 @@ impl EmailService {
     }
 
     /// Track an event (delegates to provider)
-    pub async fn track_event(
-        &self,
-        event: String,
-        email: EmailAddress,
-        subscribed: bool,
-    ) -> Result<()> {
-        self.provider.track_event(event, email, subscribed).await
+    pub async fn track_event(&self, event: String, email: EmailAddress) -> Result<()> {
+        self.provider.track_event(event, email).await
     }
 }
 

--- a/backend/tests/integration/infra.rs
+++ b/backend/tests/integration/infra.rs
@@ -121,7 +121,6 @@ impl TestClient {
         let register_request = RegisterRequest {
             email: email.clone(),
             password: password.to_string(),
-            subscribed: false,
             terms_accepted: false,
         };
 

--- a/ui/src/lib/features/auth/store.ts
+++ b/ui/src/lib/features/auth/store.ts
@@ -12,6 +12,7 @@ import type {
 } from './types/base';
 import { pushError, pushSuccess } from '$lib/shared/stores/feedback';
 import type { User } from '../users/types';
+import { resetIdentity } from '$lib/shared/utils/analytics';
 
 export const currentUser = writable<User | null>(null);
 export const isAuthenticated = writable<boolean>(false);
@@ -103,6 +104,7 @@ export async function logout(): Promise<void> {
 	if (result && result.success) {
 		isAuthenticated.set(false);
 		currentUser.set(null);
+		resetIdentity();
 		pushSuccess('Logged out successfully');
 	} else {
 		pushError('Logout failed');

--- a/ui/src/lib/features/auth/types/base.ts
+++ b/ui/src/lib/features/auth/types/base.ts
@@ -19,7 +19,6 @@ export interface LoginRequest {
 export interface RegisterRequest {
 	email: string;
 	password: string;
-	subscribed: boolean;
 	terms_accepted: boolean;
 }
 

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -3,7 +3,13 @@
 	import { goto } from '$app/navigation';
 	import { page } from '$app/stores';
 	import type { Snippet } from 'svelte';
-	import { checkAuth, isCheckingAuth, isAuthenticated } from '$lib/features/auth/store';
+	import {
+		checkAuth,
+		isCheckingAuth,
+		isAuthenticated,
+		currentUser
+	} from '$lib/features/auth/store';
+	import { identifyUser, trackPlunkEvent, disableAnalytics } from '$lib/shared/utils/analytics';
 	import Loading from '$lib/shared/components/feedback/Loading.svelte';
 	import '../app.css';
 	import { resolve } from '$app/paths';
@@ -59,6 +65,20 @@
 				opt_out_capturing_by_default: true
 			});
 			posthogInitialized = true;
+		}
+	});
+
+	// Identify user in PostHog when authenticated (skipped in demo mode by identifyUser)
+	$effect(() => {
+		if (posthogInitialized && $currentUser) {
+			identifyUser($currentUser.id, $currentUser.email, $currentUser.organization_id);
+		}
+	});
+
+	// Disable all analytics in demo mode to prevent data pollution
+	$effect(() => {
+		if (posthogInitialized && $organization?.plan?.type === 'Demo') {
+			disableAnalytics();
 		}
 	});
 
@@ -122,6 +142,13 @@
 				}
 			}
 		} else {
+			// Check for pending Plunk tracking after OIDC registration
+			const pendingPlunk = sessionStorage.getItem('pendingPlunkRegistration');
+			if (pendingPlunk && $currentUser) {
+				sessionStorage.removeItem('pendingPlunkRegistration');
+				trackPlunkEvent('register', $currentUser.email, pendingPlunk === 'true');
+			}
+
 			await getOrganization();
 
 			if ($organization) {


### PR DESCRIPTION
  Analytics improvements:
  - Add PostHog identify() on app load to link events to user profiles
  - Add resetIdentity() on logout to unlink future events
  - Disable all analytics (PostHog + Plunk) for Demo plan organizations to prevent test data from polluting production analytics

  Plunk subscription tracking:
  - Move registration tracking from backend to frontend using public API key
  - Frontend calls Plunk directly after password registration
  - OIDC registration stores preference in sessionStorage, tracks after redirect
  - Remove  field from RegisterRequest API

  Backend cleanup:
  - Remove subscribed from RegisterRequest and OidcAuthorizeParams
  - Remove subscribed from auth event metadata
  - Simplify email subscriber (no longer handles registration events)
  - Update track_event signature to remove subscribed parameter