### PR TITLE
Add Forgejo and Gitea Service Definitions

### DIFF
--- a/backend/src/server/services/definitions/forgejo.rs
+++ b/backend/src/server/services/definitions/forgejo.rs
@@ -1,0 +1,34 @@
+use crate::server::hosts::r#impl::ports::PortBase;
+use crate::server::services::definitions::{ServiceDefinitionFactory, create_service};
+use crate::server::services::r#impl::categories::ServiceCategory;
+use crate::server::services::r#impl::definitions::ServiceDefinition;
+use crate::server::services::r#impl::patterns::Pattern;
+
+#[derive(Default, Clone, Eq, PartialEq, Hash)]
+pub struct Forgejo;
+
+impl ServiceDefinition for Forgejo {
+    fn name(&self) -> &'static str {
+        "Forgejo"
+    }
+    fn description(&self) -> &'static str {
+        "DevOps platform"
+    }
+    fn category(&self) -> ServiceCategory {
+        ServiceCategory::Development
+    }
+    fn discovery_pattern(&self) -> Pattern<'_> {
+        Pattern::Endpoint(
+            PortBase::Http3000,
+            "/explore/repos",
+            "Powered by Forgejo",
+            None,
+        )
+    }
+
+    fn logo_url(&self) -> &'static str {
+        "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/forgejo.svg"
+    }
+}
+
+inventory::submit!(ServiceDefinitionFactory::new(create_service::<Forgejo>));

--- a/backend/src/server/services/definitions/gitea.rs
+++ b/backend/src/server/services/definitions/gitea.rs
@@ -1,0 +1,34 @@
+use crate::server::hosts::r#impl::ports::PortBase;
+use crate::server::services::definitions::{ServiceDefinitionFactory, create_service};
+use crate::server::services::r#impl::categories::ServiceCategory;
+use crate::server::services::r#impl::definitions::ServiceDefinition;
+use crate::server::services::r#impl::patterns::Pattern;
+
+#[derive(Default, Clone, Eq, PartialEq, Hash)]
+pub struct Gitea;
+
+impl ServiceDefinition for Gitea {
+    fn name(&self) -> &'static str {
+        "Gitea"
+    }
+    fn description(&self) -> &'static str {
+        "DevOps platform"
+    }
+    fn category(&self) -> ServiceCategory {
+        ServiceCategory::Development
+    }
+    fn discovery_pattern(&self) -> Pattern<'_> {
+        Pattern::Endpoint(
+            PortBase::Http3000,
+            "/explore/repos",
+            "Powered by Gitea",
+            None,
+        )
+    }
+
+    fn logo_url(&self) -> &'static str {
+        "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/gitea.svg"
+    }
+}
+
+inventory::submit!(ServiceDefinitionFactory::new(create_service::<Gitea>));

--- a/backend/src/server/services/definitions/mod.rs
+++ b/backend/src/server/services/definitions/mod.rs
@@ -210,6 +210,8 @@ pub mod argocd;
 pub mod bamboo;
 pub mod bitbucket_server;
 pub mod drone_ci;
+pub mod forgejo;
+pub mod gitea;
 pub mod github_enterprise;
 pub mod gitlab;
 pub mod jenkins;


### PR DESCRIPTION
## Add service definition for Forgejo and Gitea

**Description**: Gitea and Forgejo are Open Source, Self-Hostable DevOps Platforms.

**Official Website**: https://about.gitea.com/ | https://forgejo.org/
**Demo Website**: https://demo.gitea.com/ | https://v13.next.forgejo.org/

**Default Ports**: 3000

**Discovery Method**
- Pattern type: Endpoint response body from <ip>:3000/explore/repos contains "Gitea" (or "Forgejo" as applicable)
- Reasoning: Gitea uses http/3000 as it's listening port, and every page includes "Powered by Gitea" in the footer. The path `/` isn't used as some instances disable the landing page and redirect to explore directly. See my instance at https://git.konpeki.solutions for an example of this.

**Icon Source**: Dashboard Icons

**Testing**: 
- [x] Compiles successfully
- [x] Tested against real instance (describe setup below)
- [ ] Unable to test (explain why below)

**Testing Details**: 
- Forgejo Tested by running a daemon locally and pulling a docker image with `docker run -p 3000:3000 codeberg.org/forgejo/forgejo:13`. Navigate to http://localhost:3000, allow self registration, and finish the install. Then prompt network discovery.
Gitea testing is the exact same, using `docker.gitea.com/gitea:latest` instead of `codeberg.org/forgejo/forgejo:13`

**Additional Notes**: 
- Contributing Guidelines state "One service definition per PR", however as Forgejo is originally a fork of Gitea and their detections are nearly identical I'm bundling them together.
- `/explore/repo` is a bit verbose to meet the case mentioned above. `/` is possible, though may miss some non-default instances
- `Powered by Gitea` / `Powered by Forgejo` is particularly verbose, especially when used in conjunction with `/explore/repo`. This can be cut down to `Gitea` and `Forgejo` if that is preferred.