### PR TITLE
  fix: resolve network scan hangs and subnet misclassification on Unraid

### DIFF
--- a/backend/src/daemon/utils/scanner.rs
+++ b/backend/src/daemon/utils/scanner.rs
@@ -214,7 +214,12 @@ fn arp_scan_host_blocking(
         "ARP blocking: opening datalink channel"
     );
 
-    let (mut tx, mut rx) = match datalink::channel(interface, Default::default()) {
+    let config = pnet::datalink::Config {
+        read_timeout: Some(Duration::from_millis(100)),
+        ..Default::default()
+    };
+
+    let (mut tx, mut rx) = match datalink::channel(interface, config) {
         Ok(Channel::Ethernet(tx, rx)) => {
             tracing::trace!(target_ip = %target_ip, "ARP blocking: channel opened");
             (tx, rx)

--- a/backend/src/server/subnets/impl/types.rs
+++ b/backend/src/server/subnets/impl/types.rs
@@ -117,8 +117,10 @@ impl SubnetType {
             return SubnetType::Storage;
         }
 
-        // Standard LAN interfaces (catch-all for ethernet)
-        if Self::match_interface_names(&["eth", "en", "eno", "enp", "ens"], interface_name) {
+        // Standard LAN interfaces (catch-all for ethernet and Linux bridges)
+        // Note: "br" (e.g., br0) is a Linux bridge, commonly used on Unraid/Proxmox for LAN
+        // This is distinct from "br-" which is Docker's bridge naming convention
+        if Self::match_interface_names(&["eth", "en", "eno", "enp", "ens", "br"], interface_name) {
             return SubnetType::Lan;
         }
 

--- a/backend/tests/integration/infra.rs
+++ b/backend/tests/integration/infra.rs
@@ -9,13 +9,13 @@ use scanopy::server::daemons::r#impl::base::Daemon;
 use scanopy::server::networks::r#impl::Network;
 use scanopy::server::organizations::r#impl::base::Organization;
 use scanopy::server::shared::storage::generic::GenericPostgresStorage;
-use scanopy::server::shared::storage::traits::{Storage, StorableEntity};
+use scanopy::server::shared::storage::traits::{StorableEntity, Storage};
 use scanopy::server::shared::types::api::ApiResponse;
 use scanopy::server::users::r#impl::base::User;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
-use sqlx::postgres::PgPoolOptions;
 use sqlx::PgPool;
+use sqlx::postgres::PgPoolOptions;
 use std::fmt::Display;
 use std::process::{Child, Command};
 use uuid::Uuid;
@@ -341,7 +341,10 @@ pub struct TestContext {
 impl TestContext {
     /// Insert an entity directly into the database, bypassing API authorization.
     /// Useful for creating test fixtures that the current user shouldn't have access to.
-    pub async fn insert_entity<T: StorableEntity + Display>(&self, entity: &T) -> Result<T, String> {
+    pub async fn insert_entity<T: StorableEntity + Display>(
+        &self,
+        entity: &T,
+    ) -> Result<T, String> {
         let storage: GenericPostgresStorage<T> = GenericPostgresStorage::new(self.db_pool.clone());
         storage
             .create(entity)
@@ -350,7 +353,10 @@ impl TestContext {
     }
 
     /// Delete an entity directly from the database by ID.
-    pub async fn delete_entity<T: StorableEntity + Display>(&self, id: &Uuid) -> Result<(), String> {
+    pub async fn delete_entity<T: StorableEntity + Display>(
+        &self,
+        id: &Uuid,
+    ) -> Result<(), String> {
         let storage: GenericPostgresStorage<T> = GenericPostgresStorage::new(self.db_pool.clone());
         storage
             .delete(id)

--- a/backend/tests/integration/permissions.rs
+++ b/backend/tests/integration/permissions.rs
@@ -97,7 +97,10 @@ async fn test_cannot_read_host_on_other_network(
     // Try to read this host - should fail
     let result = ctx
         .client
-        .get_expect_status(&format!("/api/hosts/{}", created_host.id), StatusCode::UNAUTHORIZED)
+        .get_expect_status(
+            &format!("/api/hosts/{}", created_host.id),
+            StatusCode::UNAUTHORIZED,
+        )
         .await;
 
     // Clean up


### PR DESCRIPTION
  This addresses two issues affecting network discovery reliability:

  1. ARP Scan Hang (#374): Network scans hung indefinitely when targets didn't respond to ARP requests. The datalink channel was using default config with no read_timeout, causing rx.next() to block forever. Added 100ms read_timeout to allow deadline checks.

  2. Subnet Misclassification (#374): On Unraid/Proxmox systems where the physical LAN uses a bridge interface (br0), subnets were incorrectly classified as DockerBridge, causing network discovery to skip them.

     Root cause: Docker's macvlan/ipvlan networks (used for container LAN access) were being treated the same as bridge networks, and the filter logic was backwards - removing host subnets instead of Docker subnets when CIDRs overlapped.

     Fixes: - Filter Docker networks by driver type: only bridge/overlay are DockerBridge, skip macvlan/ipvlan/host - Flip filter precedence: host interfaces take priority over Docker networks with same CIDR - Add br to LAN interface patterns (distinct from br- which is Docker's convention)