### PR TITLE
Fix CI workflow issues

### DIFF
--- a/.github/workflows/promote_to_latest.yml
+++ b/.github/workflows/promote_to_latest.yml
@@ -113,6 +113,7 @@ jobs:
         run: |
           cd ui && npm ci --ignore-scripts
           npx svelte-kit sync
+          npx paraglide-js compile --outdir ./src/lib/paraglide --silent
           npx vite-node scripts/export-daemon-field-defs.ts docs > ../website/src/lib/fixtures/daemon-config.json
 
       - name: Get previous release tag

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add backend/Cargo.toml backend/Cargo.lock ui/package.json ui/package-lock.json
           git add backend/src/tests/scanopy.sql backend/src/tests/daemon_config.json ui/static/services.json ui/src/lib/data/billing-plans.json ui/src/lib/data/features.json ui/static/schema.mermaid ui/static/schema-er.mermaid ui/static/entity-metadata.json
+          git add backend/tests/integration/compat/fixtures/
 
           if git diff --staged --quiet; then
             echo "No fixture changes to commit"


### PR DESCRIPTION
- Add compat fixtures directory to release workflow commit step
- Add paraglide-js compile before vite-node in promote_to_latest (paraglide messages are generated by compile, not svelte-kit sync)