### PR TITLE
chore: add OCI standard labels to Docker images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -299,7 +299,18 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/server
+          labels: |
+            org.opencontainers.image.title=Scanopy Server
+            org.opencontainers.image.description=Scanopy server (community edition) — Network diagrams that update themselves.
+            org.opencontainers.image.vendor=Scanopy
+            org.opencontainers.image.licenses=AGPL-3.0-only
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -312,6 +323,7 @@ jobs:
             PUBLIC_SERVER_PORT=60072
           tags: |
             ghcr.io/${{ github.repository }}/server:${{ github.event.release.tag_name }}-${{ matrix.suffix }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=server-${{ matrix.suffix }}
           cache-to: type=gha,mode=max,scope=server-${{ matrix.suffix }}
 
@@ -356,6 +368,17 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/server-commercial
+          labels: |
+            org.opencontainers.image.title=Scanopy Server (Commercial)
+            org.opencontainers.image.description=Scanopy server (commercial edition) — Network diagrams that update themselves.
+            org.opencontainers.image.vendor=Scanopy
+            org.opencontainers.image.licenses=AGPL-3.0-only OR LicenseRef-Scanopy-Commercial
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -369,6 +392,7 @@ jobs:
             CARGO_FEATURES=commercial
           tags: |
             ghcr.io/${{ github.repository }}/server-commercial:${{ github.event.release.tag_name }}-${{ matrix.suffix }}
+          labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha,scope=server-commercial-${{ matrix.suffix }}
           cache-to: type=gha,mode=max,scope=server-commercial-${{ matrix.suffix }}
 
@@ -412,7 +436,18 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}/daemon
+          labels: |
+            org.opencontainers.image.title=Scanopy Daemon
+            org.opencontainers.image.description=Scanopy daemon — network discovery agent.
+            org.opencontainers.image.vendor=Scanopy
+            org.opencontainers.image.licenses=AGPL-3.0-only
+
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -422,6 +457,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}/daemon:${{ github.event.release.tag_name }}
+          labels: ${{ steps.meta.outputs.labels }}
 
   # ============================================
   # Create multi-arch manifests for server images

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -321,6 +321,9 @@ jobs:
           build-args: |
             PUBLIC_SERVER_HOSTNAME=default
             PUBLIC_SERVER_PORT=60072
+            OCI_IMAGE_TITLE=Scanopy Server
+            OCI_IMAGE_DESCRIPTION=Scanopy server (community edition) — Network diagrams that update themselves.
+            OCI_IMAGE_LICENSES=AGPL-3.0-only
           tags: |
             ghcr.io/${{ github.repository }}/server:${{ github.event.release.tag_name }}-${{ matrix.suffix }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -390,6 +393,9 @@ jobs:
             PUBLIC_SERVER_HOSTNAME=default
             PUBLIC_SERVER_PORT=60072
             CARGO_FEATURES=commercial
+            OCI_IMAGE_TITLE=Scanopy Server (Commercial)
+            OCI_IMAGE_DESCRIPTION=Scanopy server (commercial edition) — Network diagrams that update themselves.
+            OCI_IMAGE_LICENSES=AGPL-3.0-only OR LicenseRef-Scanopy-Commercial
           tags: |
             ghcr.io/${{ github.repository }}/server-commercial:${{ github.event.release.tag_name }}-${{ matrix.suffix }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -82,6 +82,15 @@ FROM debian:bookworm-slim AS runtime
 # Required by Kamal for container management 
 LABEL service="scanopy"
 
+# OCI Image Spec labels — https://github.com/opencontainers/image-spec/blob/main/annotations.md
+LABEL org.opencontainers.image.title="Scanopy Server" \
+      org.opencontainers.image.description="Scanopy server — Network diagrams that update themselves." \
+      org.opencontainers.image.url="https://github.com/scanopy/scanopy" \
+      org.opencontainers.image.source="https://github.com/scanopy/scanopy" \
+      org.opencontainers.image.documentation="https://github.com/scanopy/scanopy#readme" \
+      org.opencontainers.image.vendor="Scanopy" \
+      org.opencontainers.image.licenses="AGPL-3.0-only"
+
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \
     ca-certificates \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -83,13 +83,17 @@ FROM debian:bookworm-slim AS runtime
 LABEL service="scanopy"
 
 # OCI Image Spec labels — https://github.com/opencontainers/image-spec/blob/main/annotations.md
-LABEL org.opencontainers.image.title="Scanopy Server" \
-      org.opencontainers.image.description="Scanopy server — Network diagrams that update themselves." \
+# Values default to the community build; commercial CI overrides via --build-arg.
+ARG OCI_IMAGE_TITLE="Scanopy Server"
+ARG OCI_IMAGE_DESCRIPTION="Scanopy server (community edition) — Network diagrams that update themselves."
+ARG OCI_IMAGE_LICENSES="AGPL-3.0-only"
+LABEL org.opencontainers.image.title="${OCI_IMAGE_TITLE}" \
+      org.opencontainers.image.description="${OCI_IMAGE_DESCRIPTION}" \
       org.opencontainers.image.url="https://github.com/scanopy/scanopy" \
       org.opencontainers.image.source="https://github.com/scanopy/scanopy" \
       org.opencontainers.image.documentation="https://github.com/scanopy/scanopy#readme" \
       org.opencontainers.image.vendor="Scanopy" \
-      org.opencontainers.image.licenses="AGPL-3.0-only"
+      org.opencontainers.image.licenses="${OCI_IMAGE_LICENSES}"
 
 # Install runtime dependencies
 RUN apt-get update && apt-get install -y \

--- a/backend/Dockerfile.daemon
+++ b/backend/Dockerfile.daemon
@@ -16,6 +16,15 @@ RUN apt-get update && apt-get install -y \
 COPY scanopy-daemon-linux-${TARGETARCH} /usr/local/bin/scanopy-daemon
 RUN chmod +x /usr/local/bin/scanopy-daemon
 
+# OCI Image Spec labels — https://github.com/opencontainers/image-spec/blob/main/annotations.md
+LABEL org.opencontainers.image.title="Scanopy Daemon" \
+      org.opencontainers.image.description="Scanopy daemon — network discovery agent." \
+      org.opencontainers.image.url="https://github.com/scanopy/scanopy" \
+      org.opencontainers.image.source="https://github.com/scanopy/scanopy" \
+      org.opencontainers.image.documentation="https://github.com/scanopy/scanopy#readme" \
+      org.opencontainers.image.vendor="Scanopy" \
+      org.opencontainers.image.licenses="AGPL-3.0-only"
+
 EXPOSE 60073
 
 HEALTHCHECK --interval=30s --timeout=5s --retries=3 \


### PR DESCRIPTION
## Context

Add [OCI Image Spec](https://github.com/opencontainers/image-spec/blob/main/annotations.md) standard labels to the Scanopy Docker images published to GHCR so dependency bots, registry UIs, and security scanners can surface accurate image metadata.

## Type

Improvement — metadata only, no functional or runtime changes.

## Changes

### `backend/Dockerfile` (server / server-commercial)

Adds a static `LABEL` block with title, description, url, source, documentation, vendor, and licenses in the final `runtime` stage. The pre-existing `LABEL service="scanopy"` (required by Kamal) is preserved untouched.

### `backend/Dockerfile.daemon`

Adds the equivalent static `LABEL` block for the daemon image.

### `.github/workflows/release.yml`

Adds a `docker/metadata-action@v5` step to each of the three Docker build jobs (`build-docker-server-community`, `build-docker-server-commercial`, `build-docker-daemon`) and wires its `labels` output into the existing `docker/build-push-action` step via `labels: ${{ steps.meta.outputs.labels }}`.

`docker/metadata-action` auto-populates `source`, `url`, `revision`, `version`, and `created` from the GitHub release context. The `labels:` input on each call provides explicit values for `title`, `description`, `vendor`, and `licenses` (so CI values match the Dockerfile statics, and the commercial image advertises a dual-license SPDX expression).

## Labels Added

| Label | Server (community) | Server (commercial) | Daemon | Source |
|-------|-------------------|---------------------|--------|--------|
| `title` | Scanopy Server | Scanopy Server (Commercial) | Scanopy Daemon | Dockerfile + CI |
| `description` | Scanopy server — Network diagrams that update themselves. | Scanopy server (commercial edition) — … | Scanopy daemon — network discovery agent. | Dockerfile + CI |
| `url` | https://github.com/scanopy/scanopy | same | same | Dockerfile + CI |
| `source` | https://github.com/scanopy/scanopy | same | same | Dockerfile + CI auto |
| `documentation` | https://github.com/scanopy/scanopy#readme | same | same | Dockerfile |
| `vendor` | Scanopy | Scanopy | Scanopy | Dockerfile + CI |
| `licenses` | AGPL-3.0-only | AGPL-3.0-only OR LicenseRef-Scanopy-Commercial | AGPL-3.0-only | Dockerfile + CI |
| `version` | `${release.tag_name}` | `${release.tag_name}` | `${release.tag_name}` | CI (metadata-action) |
| `revision` | commit SHA | commit SHA | commit SHA | CI (metadata-action) |
| `created` | build timestamp | build timestamp | build timestamp | CI (metadata-action) |

The static `LABEL` blocks in the Dockerfiles mean local `docker build` still produces OCI-labeled images outside the release pipeline. The CI `metadata-action` overrides add dynamic values on top.

## Benefits

- **Dependency bots**: Renovate and Dependabot use `org.opencontainers.image.source` to locate changelogs and release notes when opening update PRs for consumers pulling `ghcr.io/scanopy/scanopy/server` or `/daemon`.
- **GHCR UI**: the GitHub Container Registry sidebar displays `description`, `source`, and `licenses` — these are currently empty for both images.
- **Security scanners**: Trivy, Grype, and Snyk cross-reference `source` and `revision` for provenance.
- **Image auditing**: `version` + `revision` + `created` lets consumers pin and trace exactly which commit produced a given image.

## Testing

- [x] `docker build` passes locally with the new `LABEL` instructions (pure metadata, no new dependencies).
- [x] `docker/metadata-action@v5` is a drop-in addition; the existing `build-push-action` step now receives the generated labels via `labels:`.
- [x] YAML validates (no schema changes, just new action steps).
- [ ] Full release pipeline — requires merge + release event to verify the published images carry the labels. A maintainer can verify post-merge via `docker manifest inspect ghcr.io/scanopy/scanopy/server:<tag>` or via the GHCR sidebar.

## Notes

- `LABEL service="scanopy"` (Kamal) is deliberately left in place — it's orthogonal to OCI annotations.
- License SPDX value `AGPL-3.0-only OR LicenseRef-Scanopy-Commercial` follows the [SPDX expression](https://spdx.github.io/spdx-spec/v2.3/SPDX-license-expressions/) convention for dual-licensed artifacts; adjust if you prefer a different identifier for the commercial license.
- The three non-published Dockerfiles (`backend/Dockerfile.dev`, `ui/Dockerfile.dev`, `tools/snmp/Dockerfile`) are intentionally untouched — they are dev/test-only and not pushed to any registry.

## References

- [OCI Image Spec — Annotations](https://github.com/opencontainers/image-spec/blob/main/annotations.md)
- [Renovate Docker datasource](https://docs.renovatebot.com/modules/datasource/docker/)
- [docker/metadata-action](https://github.com/docker/metadata-action)
- [Docker docs — manage tags and labels](https://docs.docker.com/build/ci/github-actions/manage-tags-labels/)
