### PR TITLE
Fix prepare_release.yml YAML literal block

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -91,7 +91,5 @@ jobs:
         # to decide whether to run the backward-compat harness / enum tests and
         # what OCI label to stamp on the built images.
         GENERATED_BODY=$(gh release view "$TAG" --json body -q '.body')
-        NEW_BODY="Deploy-Mode: ${DEPLOY_MODE}
-
-${GENERATED_BODY}"
+        NEW_BODY=$(printf 'Deploy-Mode: %s\n\n%s' "$DEPLOY_MODE" "$GENERATED_BODY")
         gh release edit "$TAG" --notes "$NEW_BODY"


### PR DESCRIPTION
The NEW_BODY bash multi-line string had a continuation line at column 0, which terminated YAML's literal scalar block early and made GitHub reject the workflow as invalid (UI showed file path instead of name and the Run workflow button was disabled). Replaced the unindented bash heredoc with printf so every line stays inside the literal block.